### PR TITLE
Removed a lost <p> from the main ul / li menu

### DIFF
--- a/_source/_includes/docs.html
+++ b/_source/_includes/docs.html
@@ -5,5 +5,4 @@
     <a href="{{ entry.url }}">{{ entry.data.title }}</a>
   </li>
   {%- endfor -%}
-  </p>
 </ul>


### PR DESCRIPTION
Hi, I just removed a lost `<p>` from the `_includes/docs.html` file.